### PR TITLE
CI/CD: Github Actions 스크립트 추가

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,0 +1,108 @@
+name: CI/CD
+
+on:
+  push:
+    branches: [ "main", "dev" ]
+
+env:
+  DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+  DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
+  IMAGE_NAME: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: JDK17 설치
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: gradlew 명령어 실행 권한 부여
+        run: chmod +x gradlew
+
+      - name: 프로젝트 빌드 및 테스트
+        run: SPRING_PROFILES_ACTIVE=test JASYPT_KEY=${{ secrets.JASYPT_KEY }} ./gradlew build
+
+      - name: 도커허브 로그인
+        uses: docker/login-action@v2
+        with:
+          username: ${{ env.DOCKER_HUB_USERNAME }}
+          password: ${{ env.DOCKER_HUB_TOKEN }}
+
+      - name: 도커 이미지 푸시
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+
+  # 운영서버 배포
+  deploy-main:
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: 도커 스웜 배포 또는 업데이트
+      uses: appleboy/ssh-action@master
+      with:
+        host: ${{ secrets.SSH_HOST }}
+        username: ${{ secrets.SSH_USER }}
+        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        password: ${{ secrets.SSH_PASSWORD }}
+        script: |
+          if docker service inspect yog >/dev/null 2>&1; then
+            echo "✅도커 스웜 서비스를 업데이트합니다."
+            docker service update --image ${{ env.IMAGE_NAME }}:main yog
+          else
+            echo "✅도커 스웜 서비스를 생성합니다."
+            docker service create \
+              --name yog \
+              --replicas 3 \
+              -p 8080:8080 \
+              -e JASYPT_KEY=${JASYPT_KEY} \
+              ${{ env.IMAGE_NAME }}:main
+          fi
+
+  # 테스트 서버 배포
+  deploy-dev:
+    if: github.ref == 'refs/heads/dev'
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 테스트 서버 배포
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.TEST_SERVER_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          password: ${{ secrets.TEST_SERVER_PASSWORD }}
+          script: |
+            CONTAINER_NAME="yog"
+            IMAGE_NAME="${{ env.IMAGE_NAME }}:dev"
+
+            echo "🔍 현재 실행 중인 컨테이너 확인 중..."
+            if [ "$(docker ps -q -f name=$CONTAINER_NAME)" ]; then
+                echo "🛑 실행 중인 컨테이너를 중지하고 삭제합니다..."
+                docker stop $CONTAINER_NAME
+                docker rm $CONTAINER_NAME
+            elif [ "$(docker ps -aq -f name=$CONTAINER_NAME)" ]; then
+                echo "⚠️ 컨테이너가 중지 상태입니다. 삭제 후 재시작합니다..."
+                docker rm $CONTAINER_NAME
+            fi
+
+            echo "📦 최신 Docker 이미지 Pull..."
+            docker pull $IMAGE_NAME
+
+            echo "🚀 새로운 컨테이너 실행..."
+            docker run -dit --name $CONTAINER_NAME -p 8080:8080 -e JASYPT_KEY=${{ secrets.JASYPT_KEY }} $IMAGE_NAME
+
+            echo "✅ 배포 완료!"


### PR DESCRIPTION
## 기능 요약
CI/CD

## 작업 내용
- DEV 브랜치 push -> 테스트 서버로 배포
- MAIN 브랜치 push -> 운영 서버로 배포

1. 프로젝트를 도커이미지로 빌드
2. 도커이미지를 도커 허브로 push
3. 테스트/운영 서버로 ssh 접속
4. 도커 이미지 pull
5. 테스트 서버일 경우 기존 컨테이너 종료 및 삭제 후 새 컨테이너 생성
6. 운영서버일 경우 도커 스웜 서비스 업데이트

## 트러블 슈팅


## 예상 결과


## 스크린샷


## 관련 이슈
