### PR TITLE
feat: WebSocket/STOMP & Kafka를 연동한 채팅 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,12 @@ dependencies {
 
     // jasypt
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
+
+    // websocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+    // kafka
+    implementation 'org.springframework.kafka:spring-kafka'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/health/yogiodigym/chat/config/ChatConstants.java
+++ b/src/main/java/com/health/yogiodigym/chat/config/ChatConstants.java
@@ -1,0 +1,8 @@
+package com.health.yogiodigym.chat.config;
+
+public interface ChatConstants {
+    String CHAT_TOPIC = "chat-room";
+    String CONNECT_URL = "/ws-connect";
+    String PUBLISH_URL = "/publish";
+    String TOPIC_URL = "/topic";
+}

--- a/src/main/java/com/health/yogiodigym/chat/config/KafkaConsumerConfiguration.java
+++ b/src/main/java/com/health/yogiodigym/chat/config/KafkaConsumerConfiguration.java
@@ -1,0 +1,50 @@
+package com.health.yogiodigym.chat.config;
+
+import com.health.yogiodigym.chat.dto.MessageDto;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+@EnableKafka
+@Configuration
+@RequiredArgsConstructor
+public class KafkaConsumerConfiguration {
+
+    private final Environment env;
+
+    @Bean
+    ConcurrentKafkaListenerContainerFactory<String, MessageDto> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, MessageDto> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+
+    @Bean
+    public ConsumerFactory<String, MessageDto> consumerFactory() {
+
+        final String GROUP_ID = env.getProperty("spring.kafka.consumer.group-id");
+
+        JsonDeserializer<MessageDto> deserializer = new JsonDeserializer<>();
+        deserializer.addTrustedPackages("*");
+
+        Map<String, Object> consumerConfigurations = new HashMap<>();
+        consumerConfigurations.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");  // TODO 서버 IP로 변경 예정
+        consumerConfigurations.put(ConsumerConfig.GROUP_ID_CONFIG, GROUP_ID);
+        consumerConfigurations.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        consumerConfigurations.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, deserializer);
+        consumerConfigurations.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+        consumerConfigurations.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+        return new DefaultKafkaConsumerFactory<>(consumerConfigurations, new StringDeserializer(), deserializer);
+    }
+
+}

--- a/src/main/java/com/health/yogiodigym/chat/config/KafkaProducerConfiguration.java
+++ b/src/main/java/com/health/yogiodigym/chat/config/KafkaProducerConfiguration.java
@@ -1,0 +1,39 @@
+package com.health.yogiodigym.chat.config;
+
+import com.health.yogiodigym.chat.dto.MessageDto;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@EnableKafka
+@Configuration
+public class KafkaProducerConfiguration {
+
+    @Bean
+    public KafkaTemplate<String, MessageDto> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    @Bean
+    public ProducerFactory<String, MessageDto> producerFactory() {
+        return new DefaultKafkaProducerFactory<>(producerConfigurations());
+    }
+
+    @Bean
+    public Map<String, Object> producerConfigurations() {
+        Map<String, Object> producerConfiguration = new HashMap<>();
+        producerConfiguration.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092"); // TODO 서버 IP로 변경 예정
+        producerConfiguration.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        producerConfiguration.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return producerConfiguration;
+    }
+
+}

--- a/src/main/java/com/health/yogiodigym/chat/config/StompHandler.java
+++ b/src/main/java/com/health/yogiodigym/chat/config/StompHandler.java
@@ -1,0 +1,35 @@
+package com.health.yogiodigym.chat.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompHandler implements ChannelInterceptor {
+
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        final StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+
+        if (StompCommand.CONNECT == accessor.getCommand()) {
+            log.info(">>> 사용자가 연결되었습니다.");
+            // TODO 사용자 세션 검증
+        }
+
+        if (StompCommand.SUBSCRIBE == accessor.getCommand()) {
+            log.info(">>> 채팅방에 입장하였습니다.");
+            // TODO 사용자 세션 검증
+        }
+
+        return message;
+    }
+
+}

--- a/src/main/java/com/health/yogiodigym/chat/config/StompWebSocketConfig.java
+++ b/src/main/java/com/health/yogiodigym/chat/config/StompWebSocketConfig.java
@@ -1,0 +1,36 @@
+package com.health.yogiodigym.chat.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSocketMessageBroker
+public class StompWebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final StompHandler stompHandler;
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint(ChatConstants.CONNECT_URL)
+                .setAllowedOrigins("http://localhost:8080", "http://localhost:8081") // TODO 변경
+                .withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.setApplicationDestinationPrefixes(ChatConstants.PUBLISH_URL);
+        registry.enableSimpleBroker(ChatConstants.TOPIC_URL);
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompHandler);
+    }
+
+}

--- a/src/main/java/com/health/yogiodigym/chat/controller/rest/StompController.java
+++ b/src/main/java/com/health/yogiodigym/chat/controller/rest/StompController.java
@@ -1,0 +1,28 @@
+package com.health.yogiodigym.chat.controller.rest;
+
+import com.health.yogiodigym.chat.config.ChatConstants;
+import com.health.yogiodigym.chat.dto.MessageDto;
+import com.health.yogiodigym.chat.service.KafkaProducerService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class StompController {
+
+    private final KafkaProducerService kafkaProducerService;
+
+    @MessageMapping("/{roomId}")
+    public MessageDto sendMessage(MessageDto message) {
+
+        log.info("전송한 메시지 : {}", message);
+
+        kafkaProducerService.sendMessage(ChatConstants.CHAT_TOPIC, message);
+
+        return message;
+    }
+
+}

--- a/src/main/java/com/health/yogiodigym/chat/dto/MessageDto.java
+++ b/src/main/java/com/health/yogiodigym/chat/dto/MessageDto.java
@@ -1,0 +1,15 @@
+package com.health.yogiodigym.chat.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class MessageDto {
+    private Long senderId;
+    private String roomId;
+    private String message;
+}

--- a/src/main/java/com/health/yogiodigym/chat/service/KafkaConsumerService.java
+++ b/src/main/java/com/health/yogiodigym/chat/service/KafkaConsumerService.java
@@ -1,0 +1,26 @@
+package com.health.yogiodigym.chat.service;
+
+import com.health.yogiodigym.chat.config.ChatConstants;
+import com.health.yogiodigym.chat.dto.MessageDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KafkaConsumerService {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @KafkaListener(topics = ChatConstants.CHAT_TOPIC, groupId = "#{T(java.util.UUID).randomUUID().toString()}")
+    public void listen(MessageDto message) {
+
+        log.info("수신한 메시지: {}", message);
+
+        messagingTemplate.convertAndSend("/topic/" + message.getRoomId(), message.getMessage());
+    }
+
+}

--- a/src/main/java/com/health/yogiodigym/chat/service/KafkaProducerService.java
+++ b/src/main/java/com/health/yogiodigym/chat/service/KafkaProducerService.java
@@ -1,0 +1,18 @@
+package com.health.yogiodigym.chat.service;
+
+import com.health.yogiodigym.chat.dto.MessageDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KafkaProducerService {
+
+    private final KafkaTemplate<String, MessageDto> kafkaTemplate;
+
+    public void sendMessage(String topic, MessageDto message) {
+        kafkaTemplate.send(topic, message);
+    }
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,18 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: none
+
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonDeserializer
+    consumer:
+      auto-offset-reset: latest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      group-id: chat-room
 
 jasypt:
   encryptor:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -9,6 +9,17 @@ spring:
   flyway:
     enabled: true
 
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonDeserializer
+    consumer:
+      auto-offset-reset: latest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      group-id: chat-room
+
 jasypt:
   encryptor:
     bean: jasyptEncryptor


### PR DESCRIPTION
## 기능 요약
채팅 기능 구현

## 작업 내용
- `WebSocket/STOMP`를 사용하여 채팅 기능 구현
- 분산 서버를 사용하므로 메시징큐 `Kafka`를 사용하여 메시지를 전달하도록 설정
- 메시지 전송 API 추가
- Kafka producer/consumer 설정 클래스 생성
- 채팅 전체 기능 구현 완료 후 Kafka IP주소를 서버 IP 주소로 변경 예정
- 로그인 기능 구현 완료 후 `StompHandler`에서 채팅 사용자 검증 예정

<br/>

### Kafka 및 Zookeeper 설치
도커가 설치되어 있으신분들은 아래 `docker-compose.yml` 파일을 사용하시고 없으시면 따로 설치해주시기 바랍니다.

```yaml
# compose 파일 버전
version: '3'
services:
  # 서비스 명
  zookeeper:
    # 사용할 이미지
    image: wurstmeister/zookeeper
    # 컨테이너명 설정
    container_name: zookeeper
    # 접근 포트 설정 (컨테이너 외부:컨테이너 내부)
    ports:
      - "2181:2181"
  # 서비스 명
  kafka:
    # 사용할 이미지
    image: wurstmeister/kafka
    # 컨테이너명 설정
    container_name: kafka
    # 접근 포트 설정 (컨테이너 외부:컨테이너 내부)
    ports:
      - "9092:9092"
    # 환경 변수 설정
    environment:
      KAFKA_ADVERTISED_HOST_NAME: localhost
      KAFKA_CREATE_TOPICS: "Topic:1:1"
      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
    # 볼륨 설정
    volumes:
      - /var/run/docker.sock
    # 의존 관계 설정
    depends_on:
      - zookeeper
```

```shell
$ docker-compose up -d
```
yml파일이 있는 경로에서 `docker-compose up -d` 실행

## 트러블 슈팅
- 각 서버의 group-id를 다르게 설정해야 토픽에서 메시지를 수신이 가능함 -> 각 서버의 group-id를 UUID를 사용한 랜덤 문자열로 사용
- 하나의 토픽이 채팅방 하나를 지칭하는 것이 아님 -> 하나의 토픽에 메시지를 저장하고 메시지에 채팅방번호를 지정

## 예상 결과
테스트 서버의 Kafka 연동 성공

## 스크린샷


## 관련 이슈
resolved: #6 