### PR TITLE
bug: ExceptionHandler 수정

### DIFF
--- a/src/main/java/com/health/yogiodigym/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/health/yogiodigym/common/exception/GlobalExceptionHandler.java
@@ -11,7 +11,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<?> globalExceptionHandler(CustomException e) {
         return ResponseEntity
-                .ok()
+                .status(e.getStatus())
                 .body(new HttpResponse(e.getStatus(), e.getMessage(), null));
     }
 }


### PR DESCRIPTION
## 기능 요약
버그 수정

<br/>

## 작업 내용
`GlobalExceptionHandler`에서 예외클래스의 `HttpStatus`를 리턴하는 것이 아닌, 항상 200 OK를 리턴하는 버그 수정

<br/>

## 예상 결과
`CustomException`의 `getStatus()` 값에 맞춰서 에러 메시지 리턴

<br/>

## 관련 이슈
resolved: #51 