### PR TITLE
bug: 안읽은 메시지 ID 기본값 추가 및 메시지 수신시 메시지 저장 버그 해결

### DIFF
--- a/src/main/java/com/health/yogiodigym/chat/config/KafkaConsumerConfiguration.java
+++ b/src/main/java/com/health/yogiodigym/chat/config/KafkaConsumerConfiguration.java
@@ -1,6 +1,6 @@
 package com.health.yogiodigym.chat.config;
 
-import com.health.yogiodigym.chat.dto.MessageDto.MessageRequestDto;
+import com.health.yogiodigym.chat.dto.MessageDto.MessageResponseDto;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -25,15 +25,15 @@ public class KafkaConsumerConfiguration {
     private final Environment env;
 
     @Bean
-    ConcurrentKafkaListenerContainerFactory<String, MessageRequestDto> kafkaListenerContainerFactory() {
-        ConcurrentKafkaListenerContainerFactory<String, MessageRequestDto> factory = new ConcurrentKafkaListenerContainerFactory<>();
+    ConcurrentKafkaListenerContainerFactory<String, MessageResponseDto> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, MessageResponseDto> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
         return factory;
     }
 
     @Bean
-    public ConsumerFactory<String, MessageRequestDto> consumerFactory() {
-        JsonDeserializer<MessageRequestDto> deserializer = new JsonDeserializer<>();
+    public ConsumerFactory<String, MessageResponseDto> consumerFactory() {
+        JsonDeserializer<MessageResponseDto> deserializer = new JsonDeserializer<>();
         deserializer.addTrustedPackages("*");
 
         Map<String, Object> consumerConfigurations = new HashMap<>();

--- a/src/main/java/com/health/yogiodigym/chat/config/KafkaProducerConfiguration.java
+++ b/src/main/java/com/health/yogiodigym/chat/config/KafkaProducerConfiguration.java
@@ -1,7 +1,6 @@
 package com.health.yogiodigym.chat.config;
 
-import com.health.yogiodigym.chat.dto.MessageDto;
-import com.health.yogiodigym.chat.dto.MessageDto.MessageRequestDto;
+import com.health.yogiodigym.chat.dto.MessageDto.MessageResponseDto;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -24,12 +23,12 @@ public class KafkaProducerConfiguration {
     private final Environment env;
 
     @Bean
-    public KafkaTemplate<String, MessageRequestDto> kafkaTemplate() {
+    public KafkaTemplate<String, MessageResponseDto> kafkaTemplate() {
         return new KafkaTemplate<>(producerFactory());
     }
 
     @Bean
-    public ProducerFactory<String, MessageRequestDto> producerFactory() {
+    public ProducerFactory<String, MessageResponseDto> producerFactory() {
         return new DefaultKafkaProducerFactory<>(producerConfigurations());
     }
 

--- a/src/main/java/com/health/yogiodigym/chat/controller/rest/StompController.java
+++ b/src/main/java/com/health/yogiodigym/chat/controller/rest/StompController.java
@@ -1,6 +1,8 @@
 package com.health.yogiodigym.chat.controller.rest;
 
 import com.health.yogiodigym.chat.dto.MessageDto.MessageRequestDto;
+import com.health.yogiodigym.chat.dto.MessageDto.MessageResponseDto;
+import com.health.yogiodigym.chat.service.ChatMessageService;
 import com.health.yogiodigym.chat.service.KafkaProducerService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,13 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class StompController {
 
     private final KafkaProducerService kafkaProducerService;
+    private final ChatMessageService chatMessageService;
 
     @MessageMapping("/{roomId}")
     public MessageRequestDto sendMessage(MessageRequestDto message) {
 
         log.info("전송한 메시지 : {}", message);
 
-        kafkaProducerService.sendMessage(message);
+        kafkaProducerService.sendMessage(chatMessageService.saveMessage(message));
 
         return message;
     }

--- a/src/main/java/com/health/yogiodigym/chat/service/KafkaConsumerService.java
+++ b/src/main/java/com/health/yogiodigym/chat/service/KafkaConsumerService.java
@@ -1,7 +1,6 @@
 package com.health.yogiodigym.chat.service;
 
 import com.health.yogiodigym.chat.config.ChatConstants;
-import com.health.yogiodigym.chat.dto.MessageDto.MessageRequestDto;
 import com.health.yogiodigym.chat.dto.MessageDto.MessageResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,16 +14,13 @@ import org.springframework.stereotype.Service;
 public class KafkaConsumerService {
 
     private final SimpMessagingTemplate messagingTemplate;
-    private final ChatMessageService chatMessageService;
 
     @KafkaListener(topics = ChatConstants.CHAT_TOPIC, groupId = "#{T(java.util.UUID).randomUUID().toString()}")
-    public void listen(MessageRequestDto message) {
+    public void listen(MessageResponseDto message) {
 
         log.info("수신한 메시지: {}", message);
 
-        MessageResponseDto messageResponse = chatMessageService.saveMessage(message);
-
-        messagingTemplate.convertAndSend("/topic/" + message.getRoomId(), messageResponse);
+        messagingTemplate.convertAndSend("/topic/" + message.getRoomId(), message);
     }
 
 }

--- a/src/main/java/com/health/yogiodigym/chat/service/KafkaProducerService.java
+++ b/src/main/java/com/health/yogiodigym/chat/service/KafkaProducerService.java
@@ -2,7 +2,7 @@ package com.health.yogiodigym.chat.service;
 
 import static com.health.yogiodigym.chat.config.ChatConstants.CHAT_TOPIC;
 
-import com.health.yogiodigym.chat.dto.MessageDto.MessageRequestDto;
+import com.health.yogiodigym.chat.dto.MessageDto.MessageResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
@@ -11,9 +11,9 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class KafkaProducerService {
 
-    private final KafkaTemplate<String, MessageRequestDto> kafkaTemplate;
+    private final KafkaTemplate<String, MessageResponseDto> kafkaTemplate;
 
-    public void sendMessage(MessageRequestDto message) {
+    public void sendMessage(MessageResponseDto message) {
         kafkaTemplate.send(CHAT_TOPIC, message);
     }
 }

--- a/src/main/java/com/health/yogiodigym/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/health/yogiodigym/chat/service/impl/ChatRoomServiceImpl.java
@@ -3,7 +3,7 @@ package com.health.yogiodigym.chat.service.impl;
 import static com.health.yogiodigym.chat.config.ChatConstants.ENTER_CHAT_ROOM_MESSAGE_PREFIX;
 import static com.health.yogiodigym.chat.config.ChatConstants.QUIT_CHAT_ROOM_MESSAGE_SUFFIX;
 
-import com.health.yogiodigym.chat.dto.MessageDto.MessageRequestDto;
+import com.health.yogiodigym.chat.dto.MessageDto.MessageResponseDto;
 import com.health.yogiodigym.chat.entity.ChatMessage;
 import com.health.yogiodigym.common.exception.LessonNotFoundException;
 import com.health.yogiodigym.lesson.entity.Lesson;
@@ -24,6 +24,8 @@ import com.health.yogiodigym.common.exception.MemberNotInChatRoomException;
 import com.health.yogiodigym.lesson.repository.LessonRepository;
 import com.health.yogiodigym.member.entity.Member;
 import com.health.yogiodigym.member.repository.MemberRepository;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -55,6 +57,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         ChatParticipant chatParticipant = ChatParticipant.builder()
                 .member(member)
                 .chatRoom(chatRoom)
+                .lastReadMessageId(0L)
                 .build();
         chatParticipantRepository.save(chatParticipant);
 
@@ -168,11 +171,13 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     }
 
     private void sendChatMessage(Member member, String roomId, String content) {
-        MessageRequestDto message = MessageRequestDto.builder()
+        MessageResponseDto message = MessageResponseDto.builder()
                 .senderId(member.getId())
                 .senderName(member.getName())
                 .roomId(roomId)
                 .message(content)
+                .profileUrl(member.getProfile())
+                .sendDate(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
                 .build();
         kafkaProducerService.sendMessage(message);
     }

--- a/src/main/resources/static/css/chat/chat.css
+++ b/src/main/resources/static/css/chat/chat.css
@@ -2,7 +2,7 @@
     width: 920px;
     height: 800px;
 }
-.row {
+.chat-container .row {
     height: 100%;
 }
 .chat-room-info {
@@ -49,31 +49,24 @@
     border-radius: 10px;
     margin-bottom: 10px;
 }
-/* 프로필 사진 크기와 스타일 */
 .profile-pic {
     width: 40px;
     height: 40px;
     border-radius: 50%;
     object-fit: cover;
-    margin-right: 10px;  /* 이미지와 이름 간 간격 */
+    margin-right: 10px;
 }
-
-/* 메시지의 헤더 (프로필 사진과 이름을 가로로 나열) */
 .message-header {
     display: flex;
-    align-items: center; /* 수직 정렬 */
-    margin-bottom: 5px; /* 아래쪽에 약간의 간격 */
+    align-items: center;
+    margin-bottom: 5px;
 }
-
-/* 시간 표시 스타일 */
 .message-time {
     font-size: 12px;
     color: gray;
-    margin-bottom: 5px;  /* 메시지와 간격 */
+    margin-bottom: 5px;
 }
-
-/* 메시지 내용 */
-p {
+.chat-container p {
     margin: 0;
 }
 

--- a/src/test/java/com/health/yogiodigym/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/health/yogiodigym/chat/service/ChatRoomServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.health.yogiodigym.chat.dto.MessageDto.MessageRequestDto;
+import com.health.yogiodigym.chat.dto.MessageDto.MessageResponseDto;
 import com.health.yogiodigym.lesson.entity.Lesson;
 import com.health.yogiodigym.lesson.entity.LessonEnrollment;
 import com.health.yogiodigym.lesson.repository.LessonEnrollmentRepository;
@@ -95,7 +96,7 @@ class ChatRoomServiceTest {
 
             // then
             verify(chatParticipantRepository, times(1)).save(any(ChatParticipant.class));
-            verify(kafkaProducerService, times(1)).sendMessage(any(MessageRequestDto.class));
+            verify(kafkaProducerService, times(1)).sendMessage(any(MessageResponseDto.class));
         }
 
         @Test
@@ -350,9 +351,9 @@ class ChatRoomServiceTest {
             // then
             verify(chatParticipantRepository, times(1)).delete(mockChatParticipant);
 
-            ArgumentCaptor<MessageRequestDto> messageArgumentCaptor = ArgumentCaptor.forClass(MessageRequestDto.class);
+            ArgumentCaptor<MessageResponseDto> messageArgumentCaptor = ArgumentCaptor.forClass(MessageResponseDto.class);
             verify(kafkaProducerService, times(1)).sendMessage(messageArgumentCaptor.capture());
-            MessageRequestDto message = messageArgumentCaptor.getValue();
+            MessageResponseDto message = messageArgumentCaptor.getValue();
             assertThat(message.getSenderId()).isEqualTo(mockMember.getId());
             assertThat(message.getRoomId()).isEqualTo(roomId);
             assertThat(message.getMessage()).isEqualTo(mockMember.getName() + QUIT_CHAT_ROOM_MESSAGE_SUFFIX);


### PR DESCRIPTION
## 기능 요약
채팅 버그 해결

## 작업 내용
- 처음 채팅방 입장 후 채팅 메시지 전송하더라도 안읽은 메시지 ID 값이 null이므로 메시지 조회 불가 버그 해결
- 메시지 수신시 메시지 저장 로직을 수행해 서버 개수만큼 메시지가 저장되는 버그 해결
- css 클래스 네이밍 수정

## 스크린샷


## 관련 이슈
resolved: #118 