### PR TITLE
feat: 채팅 강퇴 추가 및 버그 수정

### DIFF
--- a/src/main/java/com/health/yogiodigym/chat/dto/ChatParticipantDto.java
+++ b/src/main/java/com/health/yogiodigym/chat/dto/ChatParticipantDto.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
-
 @Getter
 @Setter
 @Builder
@@ -17,11 +16,13 @@ import lombok.ToString;
 @NoArgsConstructor
 public class ChatParticipantDto {
     private Long memberId;
+    private Long instructorId;
     private String memberName;
     private String profileUrl;
 
-    public ChatParticipantDto(Member member) {
+    public ChatParticipantDto(Member member, Long instructorId) {
         this.memberId = member.getId();
+        this.instructorId = instructorId;
         this.memberName = member.getName();
         this.profileUrl = member.getProfile();
     }

--- a/src/main/java/com/health/yogiodigym/chat/dto/ChatRoomDto.java
+++ b/src/main/java/com/health/yogiodigym/chat/dto/ChatRoomDto.java
@@ -19,21 +19,17 @@ public class ChatRoomDto {
         private boolean isGroupChat;
         private int notReadMessageCnt;
 
-        public ChatRoomResponseDto(Lesson lesson, int notReadMessageCnt) {
-            ChatRoom chatRoom = lesson.getChatRoom();
-            this.id = chatRoom.getId();
-            this.roomId = chatRoom.getRoomId();
-            this.lessonTitle = lesson.getTitle();
-            this.isGroupChat = chatRoom.isGroupChat();
-            this.notReadMessageCnt = notReadMessageCnt;
-        }
-
         public ChatRoomResponseDto(Lesson lesson) {
             ChatRoom chatRoom = lesson.getChatRoom();
             this.id = chatRoom.getId();
             this.roomId = chatRoom.getRoomId();
             this.lessonTitle = lesson.getTitle();
             this.isGroupChat = chatRoom.isGroupChat();
+        }
+
+        public ChatRoomResponseDto(Lesson lesson, int notReadMessageCnt) {
+            this(lesson);
+            this.notReadMessageCnt = notReadMessageCnt;
         }
     }
 }

--- a/src/main/java/com/health/yogiodigym/chat/service/impl/ChatParticipantServiceImpl.java
+++ b/src/main/java/com/health/yogiodigym/chat/service/impl/ChatParticipantServiceImpl.java
@@ -6,7 +6,10 @@ import com.health.yogiodigym.chat.repository.ChatParticipantRepository;
 import com.health.yogiodigym.chat.repository.ChatRoomRepository;
 import com.health.yogiodigym.chat.service.ChatParticipantService;
 import com.health.yogiodigym.common.exception.ChatRoomNotFoundException;
+import com.health.yogiodigym.common.exception.LessonNotFoundException;
 import com.health.yogiodigym.common.exception.MemberNotInChatRoomException;
+import com.health.yogiodigym.lesson.entity.Lesson;
+import com.health.yogiodigym.lesson.repository.LessonRepository;
 import com.health.yogiodigym.member.entity.Member;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ChatParticipantServiceImpl implements ChatParticipantService {
 
     private final ChatRoomRepository chatRoomRepository;
+    private final LessonRepository lessonRepository;
     private final ChatParticipantRepository chatParticipantRepository;
 
     @Override
@@ -27,12 +31,15 @@ public class ChatParticipantServiceImpl implements ChatParticipantService {
         ChatRoom chatRoom = chatRoomRepository.findByRoomId(roomId)
                 .orElseThrow(() -> new ChatRoomNotFoundException(roomId));
 
+        Lesson lesson = lessonRepository.findByChatRoom(chatRoom)
+                        .orElseThrow(LessonNotFoundException::new);
+
         chatParticipantRepository.findByMemberAndChatRoom(member, chatRoom)
                         .orElseThrow(() -> new MemberNotInChatRoomException(member.getId()));
 
         return chatParticipantRepository.findAllByChatRoom(chatRoom)
                 .stream()
-                .map(c -> new ChatParticipantDto(c.getMember()))
+                .map(c -> new ChatParticipantDto(c.getMember(), lesson.getMaster().getId()))
                 .toList();
     }
 }

--- a/src/main/java/com/health/yogiodigym/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/health/yogiodigym/chat/service/impl/ChatRoomServiceImpl.java
@@ -3,13 +3,9 @@ package com.health.yogiodigym.chat.service.impl;
 import static com.health.yogiodigym.chat.config.ChatConstants.ENTER_CHAT_ROOM_MESSAGE_PREFIX;
 import static com.health.yogiodigym.chat.config.ChatConstants.QUIT_CHAT_ROOM_MESSAGE_SUFFIX;
 
+import com.health.yogiodigym.chat.dto.ChatRoomDto.ChatRoomResponseDto;
 import com.health.yogiodigym.chat.dto.MessageDto.MessageResponseDto;
 import com.health.yogiodigym.chat.entity.ChatMessage;
-import com.health.yogiodigym.common.exception.LessonNotFoundException;
-import com.health.yogiodigym.lesson.entity.Lesson;
-import com.health.yogiodigym.lesson.entity.LessonEnrollment;
-import com.health.yogiodigym.lesson.repository.LessonEnrollmentRepository;
-import com.health.yogiodigym.chat.dto.ChatRoomDto.ChatRoomResponseDto;
 import com.health.yogiodigym.chat.entity.ChatParticipant;
 import com.health.yogiodigym.chat.entity.ChatRoom;
 import com.health.yogiodigym.chat.repository.ChatMessageRepository;
@@ -19,9 +15,17 @@ import com.health.yogiodigym.chat.service.ChatRoomService;
 import com.health.yogiodigym.chat.service.KafkaProducerService;
 import com.health.yogiodigym.common.exception.AlreadyChatParticipantException;
 import com.health.yogiodigym.common.exception.ChatRoomNotFoundException;
+import com.health.yogiodigym.common.exception.ForbiddenException;
+import com.health.yogiodigym.common.exception.KickInstructorException;
+import com.health.yogiodigym.common.exception.LessonNotFoundException;
 import com.health.yogiodigym.common.exception.MemberNotFoundException;
 import com.health.yogiodigym.common.exception.MemberNotInChatRoomException;
+import com.health.yogiodigym.common.exception.MemberNotInLessonException;
+import com.health.yogiodigym.lesson.entity.Lesson;
+import com.health.yogiodigym.lesson.entity.LessonEnrollment;
+import com.health.yogiodigym.lesson.repository.LessonEnrollmentRepository;
 import com.health.yogiodigym.lesson.repository.LessonRepository;
+import com.health.yogiodigym.member.auth.Role;
 import com.health.yogiodigym.member.entity.Member;
 import com.health.yogiodigym.member.repository.MemberRepository;
 import java.time.LocalDateTime;
@@ -81,6 +85,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         ChatParticipant chatParticipant = ChatParticipant.builder()
                 .chatRoom(chatRoom)
                 .member(member)
+                .lastReadMessageId(0L)
                 .build();
         chatParticipantRepository.save(chatParticipant);
 
@@ -131,14 +136,28 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     public void kickMember(Member instructor, Long memberId, String chatRoomId) {
         ChatRoom chatRoom = chatRoomRepository.findByRoomId(chatRoomId)
                 .orElseThrow(() -> new ChatRoomNotFoundException(chatRoomId));
+        Lesson lesson = lessonRepository.findByChatRoom(chatRoom)
+                .orElseThrow(LessonNotFoundException::new);
+
+        if (lesson.getMaster().getId().equals(memberId)) {
+            throw new KickInstructorException();
+        }
         chatParticipantRepository.findByMemberAndChatRoom(instructor, chatRoom)
                 .orElseThrow(() -> new MemberNotInChatRoomException(instructor.getId()));
+
+        if (!instructor.getRoles().contains(Role.ROLE_MASTER)) {
+            throw new ForbiddenException();
+        }
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
         ChatParticipant memberParticipant = chatParticipantRepository.findByMemberAndChatRoom(member, chatRoom)
                 .orElseThrow(() -> new MemberNotInChatRoomException(memberId));
         chatParticipantRepository.delete(memberParticipant);
+
+        LessonEnrollment lessonEnrollment = lessonEnrollmentRepository.findByLessonAndMember(lesson, member)
+                .orElseThrow(MemberNotInLessonException::new);
+        lessonEnrollmentRepository.delete(lessonEnrollment);
     }
 
     @Override

--- a/src/main/java/com/health/yogiodigym/common/exception/ForbiddenException.java
+++ b/src/main/java/com/health/yogiodigym/common/exception/ForbiddenException.java
@@ -1,0 +1,18 @@
+package com.health.yogiodigym.common.exception;
+
+import static com.health.yogiodigym.common.message.ErrorMessage.FORBIDDEN_ERROR;
+
+import org.springframework.http.HttpStatus;
+
+public class ForbiddenException extends CustomException {
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.FORBIDDEN;
+    }
+
+    @Override
+    public String getMessage() {
+        return FORBIDDEN_ERROR.getMessage();
+    }
+}

--- a/src/main/java/com/health/yogiodigym/common/exception/KickInstructorException.java
+++ b/src/main/java/com/health/yogiodigym/common/exception/KickInstructorException.java
@@ -1,0 +1,18 @@
+package com.health.yogiodigym.common.exception;
+
+import static com.health.yogiodigym.common.message.ErrorMessage.KICK_INSTRUCTOR_ERROR;
+
+import org.springframework.http.HttpStatus;
+
+public class KickInstructorException extends CustomException {
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+
+    @Override
+    public String getMessage() {
+        return KICK_INSTRUCTOR_ERROR.getMessage();
+    }
+}

--- a/src/main/java/com/health/yogiodigym/common/exception/MemberNotInLessonException.java
+++ b/src/main/java/com/health/yogiodigym/common/exception/MemberNotInLessonException.java
@@ -1,0 +1,18 @@
+package com.health.yogiodigym.common.exception;
+
+import static com.health.yogiodigym.common.message.ErrorMessage.LESSON_NOT_FOUND;
+
+import org.springframework.http.HttpStatus;
+
+public class MemberNotInLessonException extends CustomException {
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+
+    @Override
+    public String getMessage() {
+        return LESSON_NOT_FOUND.getMessage();
+    }
+}

--- a/src/main/java/com/health/yogiodigym/common/message/ErrorMessage.java
+++ b/src/main/java/com/health/yogiodigym/common/message/ErrorMessage.java
@@ -1,6 +1,5 @@
 package com.health.yogiodigym.common.message;
 
-import com.health.yogiodigym.common.exception.CodeNotMatchException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -24,13 +23,16 @@ public enum ErrorMessage {
     CHAT_ROOM_NOT_FOUND("채팅방이 존재하지 않습니다."),
     CATEGORY_NOT_FOUND("카테고리가 존재하지 않습니다."),
     MEMBER_NOT_IN_CHAT_ROOM("채팅방 참여자가 아닙니다."),
+    MEMBER_NOT_IN_LESSON("강의 참여자가 아닙니다."),
+    KICK_INSTRUCTOR_ERROR("강의의 강사는 강퇴할 수 없습니다."),
     ALREADY_CHAT_PARTICIPANT("이미 채팅방에 참여중입니다."),
     WRONG_PASSWORD_ERROR("잘못된 비밀번호입니다."),
     NO_DELETE_PERMISSION("삭제 권한이 없습니다."),
     SEND_MAIL_FAIL_ERROR("코드메일 전송에 실패했습니다."),
     EMAILCODE_NOT_FOUND("인증코드를 찾지 못했습니다"),
     CODE_NOT_MATCH_ERROR("인증코드가 일치하지 않습니다."),
-    SOCIAL_MEMBER_PWD_CHANGE_ERROR("소셜회원은 비밀번호 변경을 하실 수 없습니다.");
+    SOCIAL_MEMBER_PWD_CHANGE_ERROR("소셜회원은 비밀번호 변경을 하실 수 없습니다."),
+    FORBIDDEN_ERROR("권한이 없습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/health/yogiodigym/config/RedisConfig.java
+++ b/src/main/java/com/health/yogiodigym/config/RedisConfig.java
@@ -7,8 +7,6 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration

--- a/src/main/resources/static/css/chat/chat.css
+++ b/src/main/resources/static/css/chat/chat.css
@@ -71,3 +71,7 @@
     margin: 0;
 }
 
+.kick-button {
+    margin-right: auto;
+}
+

--- a/src/main/resources/static/js/chat/chat.js
+++ b/src/main/resources/static/js/chat/chat.js
@@ -199,3 +199,24 @@ function loadNewReadMessages() {
         }
     });
 }
+
+function kickMember(memberId) {
+    $.ajax({
+        url: `/api/chat-rooms/${chatRoomId}/members/${memberId}`,
+        method: 'DELETE',
+        dataType: 'json',
+        contentType: 'application/json; charset=utf-8',
+        beforeSend: function (xhr) {
+            xhr.setRequestHeader(csrfHeader, csrfToken);
+        },
+        success: function(response) {
+            alert(response.message);
+            location.reload();
+        },
+        error: function(jqXHR, textStatus, errorThrown) {
+            let errorResponse = JSON.parse(jqXHR.responseText);
+            console.log('status: ', errorResponse.status, 'message: ', errorResponse.message);
+            alert(errorResponse.message);
+        }
+    })
+}

--- a/src/main/resources/templates/chat/chat.html
+++ b/src/main/resources/templates/chat/chat.html
@@ -8,6 +8,7 @@
     <script src="https://cdn.jsdelivr.net/npm/sockjs-client/dist/sockjs.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/stompjs/lib/stomp.min.js"></script>
     <script defer src="/js/chat/chat.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 
     <style>
@@ -60,7 +61,7 @@
         <div th:replace="~{fragments/side :: side}"></div>
         <div class="content">
             <div class="chat-container">
-                <!--채팅방정보-->
+
                 <div class="chat-room-info">
                     <div class="card chat-room">
                         <div class="card-header text-white bg-primary">
@@ -82,14 +83,22 @@
                         </div>
                         <div class="card-body p-2">
                             <div th:each="cp : ${chatParticipants}" class="d-flex align-items-center mb-2">
-                                <img th:src="${cp.profileUrl}" class="rounded-circle me-2" width="35" height="35">
-                                <span class="fw-semibold">[[ ${cp.memberName} ]]</span>
+                                <div class="d-flex align-items-center">
+                                    <img th:src="${cp.profileUrl != null} ? ${cp.profileUrl} : '/images/source/anonymous.png'" class="rounded-circle me-2" width="35" height="35">
+                                    <span class="fw-semibold">[[ ${cp.memberName} ]]</span>
+                                </div>
+
+                                <button class="btn btn-danger btn-sm kick-button"
+                                        th:if="${cp.getInstructorId() == #authentication.principal.member.getId()
+                                            && cp.getInstructorId() != cp.getMemberId()}"
+                                        th:attr="onclick=|kickMember('${cp.memberId}')|">
+                                    강퇴
+                                </button>
                             </div>
                         </div>
                     </div>
                 </div>
 
-                <!--채팅메시지-->
                 <div class="col-md-9 chat-message-info">
                     <div class="card shadow-sm chat-content">
                         <div class="card-header text-white bg-dark">
@@ -100,7 +109,7 @@
                                  th:classappend="${rm.senderId == #authentication.principal.member.getId()} ? 'my-message' : 'other-message'">
 
                                 <div class="message-header">
-                                    <img th:src="${rm.profileUrl != null} ? ${rm.profileUrl} : '/images/default-profile.png'"
+                                    <img th:src="${rm.profileUrl != null} ? ${rm.profileUrl} : '/images/source/anonymous.png'"
                                          alt="프로필 사진" class="profile-pic" />
                                     <strong>[[ ${rm.senderName} ]]</strong>
                                 </div>
@@ -118,7 +127,7 @@
                                      th:classappend="${urm.senderId == #authentication.principal.member.getId()} ? 'my-message' : 'other-message'">
 
                                     <div class="message-header">
-                                        <img th:src="${urm.profileUrl != null} ? ${urm.profileUrl} : '/images/default-profile.png'"
+                                        <img th:src="${urm.profileUrl != null} ? ${urm.profileUrl} : '/images/source/anonymous.png'"
                                              alt="프로필 사진" class="profile-pic" />
                                         <strong>[[ ${urm.senderName} ]]</strong>
                                     </div>
@@ -152,6 +161,5 @@
 <input id="last_message_id" th:type="hidden" th:value="${lastMessageId}">
 
 <link href="/css/chat/chat.css" rel="stylesheet">
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/src/test/java/com/health/yogiodigym/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/health/yogiodigym/chat/service/ChatRoomServiceTest.java
@@ -28,10 +28,13 @@ import com.health.yogiodigym.common.exception.AlreadyChatParticipantException;
 import com.health.yogiodigym.common.exception.ChatRoomNotFoundException;
 import com.health.yogiodigym.common.exception.MemberNotInChatRoomException;
 import com.health.yogiodigym.lesson.repository.LessonRepository;
+import com.health.yogiodigym.member.auth.Role;
 import com.health.yogiodigym.member.entity.Member;
 import com.health.yogiodigym.member.repository.MemberRepository;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -268,7 +271,8 @@ class ChatRoomServiceTest {
         @DisplayName("채팅방 회원 강퇴 성공")
         void testKickMember() {
             // given
-            Lesson mockLesson = Lesson.builder().id(1L).build();
+            Member mockInstructor = Member.builder().id(instructorId).roles(new HashSet<>(Set.of(Role.ROLE_MASTER))).build();
+            Lesson mockLesson = Lesson.builder().id(1L).master(mockInstructor).build();
             when(lessonRepository.findByChatRoom(any(ChatRoom.class)))
                     .thenReturn(Optional.of(mockLesson));
 
@@ -279,7 +283,6 @@ class ChatRoomServiceTest {
                     .build();
             when(chatRoomRepository.findByRoomId(anyString())).thenReturn(Optional.of(mockChatRoom));
 
-            Member mockInstructor = Member.builder().id(instructorId).build();
             when(memberRepository.findById(anyLong())).thenReturn(Optional.of(mockInstructor));
 
             ChatParticipant chatParticipant = ChatParticipant.builder()


### PR DESCRIPTION
## 기능 요약
화면 수정
버그 수정

## 작업 내용
- 채팅화면에서 강퇴 버튼 추가
- 채팅방 최초 생성시 lastMessageId 필드에 0추가
- 강사를 강퇴지정할 경우 예외 발생
- 회원은 강퇴 버튼이 보이지 않게 구현
- 강사는 본인을 제외한 채팅 참여자 옆에 강퇴 버튼 표시
- MASTER 권한이 없을 경우 예외 발생

## 관련 이슈
resolves: #135  #136 