### PR TITLE
bug: 채팅 메시지 버그 수정

### DIFF
--- a/src/main/java/com/health/yogiodigym/chat/controller/view/ChatViewController.java
+++ b/src/main/java/com/health/yogiodigym/chat/controller/view/ChatViewController.java
@@ -34,7 +34,7 @@ public class ChatViewController {
         Long lastMessageId = chatMessageService.getLastMessageId(member, roomId);
         model.addAttribute("lastMessageId", lastMessageId);
         model.addAttribute("roomId", roomId);
-        model.addAttribute("totalPage", chatMessageService.getTotalPage(member, roomId));
+        model.addAttribute("totalPage", chatMessageService.getTotalPage(roomId, lastMessageId));
         model.addAttribute("chatParticipants", chatParticipantService.getChatParticipants(member, roomId));
         model.addAttribute("chatRooms", chatRoomService.getChatRooms(member));
         model.addAttribute("chatRoomDetail", chatRoomService.getChatRoomDetail(roomId));

--- a/src/main/java/com/health/yogiodigym/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/health/yogiodigym/chat/repository/ChatMessageRepository.java
@@ -2,7 +2,6 @@ package com.health.yogiodigym.chat.repository;
 
 import com.health.yogiodigym.chat.entity.ChatMessage;
 import com.health.yogiodigym.chat.entity.ChatRoom;
-import com.health.yogiodigym.member.entity.Member;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -24,5 +23,5 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
                             Long lastReadMessageId,
                             Pageable pageable);
 
-    Long countByMemberAndChatRoom(Member member, ChatRoom chatRoom);
+    Long countByChatRoomAndIdLessThanEqual(ChatRoom chatRoom, Long lastMessageId);
 }

--- a/src/main/java/com/health/yogiodigym/chat/service/ChatMessageService.java
+++ b/src/main/java/com/health/yogiodigym/chat/service/ChatMessageService.java
@@ -17,5 +17,5 @@ public interface ChatMessageService {
 
     Long getLastMessageId(Member member, String roomId);
 
-    int getTotalPage(Member member, String roomId);
+    int getTotalPage(String roomId, Long lastMessageId);
 }

--- a/src/main/java/com/health/yogiodigym/chat/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/com/health/yogiodigym/chat/service/impl/ChatMessageServiceImpl.java
@@ -20,11 +20,13 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -117,11 +119,11 @@ public class ChatMessageServiceImpl implements ChatMessageService {
 
     @Override
     @Transactional(readOnly = true)
-    public int getTotalPage(Member member, String roomId) {
+    public int getTotalPage(String roomId, Long lastMessageId) {
         ChatRoom chatRoom = chatRoomRepository.findByRoomId(roomId)
                 .orElseThrow(() -> new ChatRoomNotFoundException(roomId));
 
-        long totalCount = chatMessageRepository.countByMemberAndChatRoom(member, chatRoom);
+        long totalCount = chatMessageRepository.countByChatRoomAndIdLessThanEqual(chatRoom, lastMessageId);
         return (int) Math.ceil((double) totalCount / PAGE_SIZE);
     }
 

--- a/src/main/resources/static/js/chat/chat.js
+++ b/src/main/resources/static/js/chat/chat.js
@@ -118,7 +118,7 @@ function showMessage(message, isRead) {
     messageHeader.classList.add("message-header");
 
     let profileImg = document.createElement("img");
-    profileImg.setAttribute("src", message.profileUrl ? message.profileUrl : "/images/default-profile.png");
+    profileImg.setAttribute("src", message.profileUrl ? message.profileUrl : "/images/source/anonymous.png");
     profileImg.setAttribute("alt", "프로필 사진");
     profileImg.classList.add("profile-pic");
 


### PR DESCRIPTION
## 기능 요약
채팅 메시지 버그 수정

## 작업 내용
- 채팅방 사용자의 기본 이미지 수정
- 기존 : 전체 페이지의 개수를 현재 로그인한 사용자를 기준으로 가져오도록 되어 있으므로 모든 페이지의 개수가 아닌 사용자가 보낸 메시지의 전체 개수를 호출
- 수정 : 현재 채팅방을 기준으로 전체 페이지의 개수 조회


## 관련 이슈
resolves: #150 #146 