### PR TITLE
cicd: 도커 배포 컨테이너 시간대 조정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ ARG JAR_FILE=build/libs/*.jar
 ARG PROFILES
 ARG JASYPT_KEY
 
+ENV TZ=Asia/Seoul
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 WORKDIR /app
 
 COPY ${JAR_FILE} app.jar


### PR DESCRIPTION
## 기능 요약
도커 배포 컨테이너 시간대 조정

## 작업 내용
- 도커 배포 컨테이너 시간대를 KST로 설정하고 배포하도록 수정
- 도커 실행 명령어가 아닌 Dockerfile에 설정

## 관련 이슈
resolved: #148 